### PR TITLE
Fix: add composer.lock for cloud builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,6 @@
     "name": "kinsta/hello-world-php",
     "description": "An example of how to set your PHP application up to enable deployment on Kinsta App Hosting services.",
     "require": {
-        "php": "8.2"
+        "php": "8.2.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e68695f4bdc77650b5d6b0c180b62aa5",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "8.2.*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Fixing error with buildpacks:

```
[Error: No Composer lock file found]
A 'composer.lock' file was not found in your project, but there
is a 'composer.json' file with dependencies inside 'require'.
```